### PR TITLE
fixed links to nature article and small spelling things

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
 	<section class="slide"><div>
 		<h2>Temporary Notebook System - tmpnb</h2>
 		<h3><a href="https://github.com/jupyter/tmpnb">github.com/jupyter/tmpnb</a></h3>
-		<p>Originally built for [a demo](http://www.nature.com/news/ipython-interactive-demo-7.21492?article=1.16261) as part of a [Nature article on IPython](http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261)</p>
+		<p>Originally built for <a href="http://www.nature.com/news/ipython-interactive-demo-7.21492?article=1.16261">a demo</a> as part of a <a href="http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261">Nature article on IPython</a></p>
 	</div></section>
 
 	<section class="slide"><div>
@@ -163,7 +163,7 @@
 	</style>
 
 	<section class="slide"><div>
-		<h2>Not These people</h2>
+		<h2>Not These People</h2>
 		<img src="pictures/not-this-guy.png" class="slide-img" style="width: 60%" alt="Typity type type">
 
 	</div></section>


### PR DESCRIPTION
The links to your nature article and demo were markdown, rather than HTML, so's I fixed 'em.
